### PR TITLE
chore: added WASM support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
-## [3.0.0] - 2024/06/XX
+## [3.0.1] - 2024/09/12
+
+* Minor dependency bumps
+* Minor documentation improvements
+
+## [3.0.0] - 2024/06/08
 
 * Updated to support flutter_map v7
 

--- a/README.md
+++ b/README.md
@@ -15,5 +15,3 @@ Although HTTP request abortion is supported on all platforms, it is especially u
 On other platforms, the other benefits may still occur, but may not be as visible as on the web.
 
 Once HTTP request abortion is [added to Dart's 'native' 'http' package (which already has a PR opened)](https://github.com/dart-lang/http/issues/424), `NetworkTileProvider` will be updated to take advantage of it, replacing and deprecating this provider. This tile provider is currently a separate package and not the default due to the reliance on the additional Dio dependency.
-
-> WASM is currently not supported, because Dio does not yet support it.

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,3 @@
+# Examples
+
+See the [examples](https://docs.fleaflet.dev/getting-started/examples) on the main flutter_map repo, which use this plugin.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_map_cancellable_tile_provider
 description: Plugin for flutter_map that provides a `TileProvider` with the capability to cancel unnecessary HTTP tile requests
-version: 3.0.0
+version: 3.0.1
 
 homepage: https://github.com/fleaflet/flutter_map
 repository: https://github.com/fleaflet/flutter_map_cancellable_tile_provider
@@ -27,8 +27,8 @@ environment:
   flutter: ">=3.10.0"
 
 dependencies:
-  dio: ^5.4.3
+  dio: ^5.7.0
   flutter:
     sdk: flutter
-  flutter_map: ^7.0.0
-  meta: ^1.11.0
+  flutter_map: ^7.0.2
+  meta: ^1.15.0


### PR DESCRIPTION
Technically nothing has changed here to support Wasm. Due to the way the dependencies were setup, now that Dio supports Wasm, users don't even need to upgrade this package.

However, I've bumped this to the next patch though, as it gives a chance to upgrade the dependencies (even though it doesn't particularly matter, as none were upgraded past a major/breaking version) and documenatation to remove the 'we don't support Wasm' disclaimer.