### PR TITLE
iOS and Server Error Fix Plus Potential Major Speed Increase

### DIFF
--- a/lib/src/dio_singleton.dart
+++ b/lib/src/dio_singleton.dart
@@ -1,14 +1,22 @@
+import 'dart:io'; // Platform.is
 import 'package:flutter/foundation.dart'; // kIsWeb
 import 'package:dio/dio.dart';
 
 /// Remove if kIsWeb or won't compile
 import 'package:native_dio_adapter/native_dio_adapter.dart';
 
+class GetPlatform {
+  static const bool isWeb = kIsWeb;
+  static final bool isIOS = !kIsWeb && (Platform.isIOS || Platform.isMacOS);
+  static final bool isAndroid = !kIsWeb && Platform.isAndroid;
+  static final bool isWindows = !kIsWeb && Platform.isWindows;
+}
+
 class DioSingleton {
   static final Dio _dio = Dio();
 
   static Dio get dioInstance {
-    if (!kIsWeb) {
+    if (GetPlatform.isIOS) {
       _dio.httpClientAdapter = NativeAdapter();
     }
     return _dio;

--- a/lib/src/dio_singleton.dart
+++ b/lib/src/dio_singleton.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/foundation.dart'; // kIsWeb
+import 'package:dio/dio.dart';
+
+/// Remove if kIsWeb or won't compile
+import 'package:native_dio_adapter/native_dio_adapter.dart';
+
+class DioSingleton {
+  static final Dio _dio = Dio();
+
+  static Dio get dioInstance {
+    if (!kIsWeb) {
+      _dio.httpClientAdapter = NativeAdapter();
+    }
+    return _dio;
+  }
+}

--- a/lib/src/image_provider.dart
+++ b/lib/src/image_provider.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 import 'dart:ui';
-
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:meta/meta.dart';
+import 'dio_singleton.dart';
 
 @internal
 @visibleForTesting
@@ -14,17 +14,18 @@ class CancellableNetworkImageProvider
   final String url;
   final String? fallbackUrl;
   final Map<String, String> headers;
-  final Dio dioClient;
   final Future<void> cancelLoading;
   final bool silenceExceptions;
   final void Function() startedLoading;
   final void Function() finishedLoadingBytes;
 
+  /// Use singleton Dio
+  final Dio dioClient = DioSingleton.dioInstance;
+
   const CancellableNetworkImageProvider({
     required this.url,
     required this.fallbackUrl,
     required this.headers,
-    required this.dioClient,
     required this.cancelLoading,
     required this.silenceExceptions,
     required this.startedLoading,

--- a/lib/src/image_provider.dart
+++ b/lib/src/image_provider.dart
@@ -18,9 +18,7 @@ class CancellableNetworkImageProvider
   final bool silenceExceptions;
   final void Function() startedLoading;
   final void Function() finishedLoadingBytes;
-
-  /// Use singleton Dio
-  final Dio dioClient = DioSingleton.dioInstance;
+  final Dio dioClient;
 
   const CancellableNetworkImageProvider({
     required this.url,
@@ -30,6 +28,7 @@ class CancellableNetworkImageProvider
     required this.silenceExceptions,
     required this.startedLoading,
     required this.finishedLoadingBytes,
+    required this.dioClient,
   });
 
   @override

--- a/lib/src/tile_provider.dart
+++ b/lib/src/tile_provider.dart
@@ -95,6 +95,7 @@ base class CancellableNetworkTileProvider extends TileProvider {
           _tilesInProgress[coordinates]?.complete();
           _tilesInProgress.remove(coordinates);
         },
+        dioClient: _dioClient,
       );
 
   @override

--- a/lib/src/tile_provider.dart
+++ b/lib/src/tile_provider.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 import 'dart:collection';
-
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_map/flutter_map.dart';
-
+import 'dio_singleton.dart';
 import 'image_provider.dart';
 
 /// [TileProvider] that fetches tiles from the network, with the capability to
@@ -54,9 +54,8 @@ base class CancellableNetworkTileProvider extends TileProvider {
   /// {@macro fmctp-desc}
   CancellableNetworkTileProvider({
     super.headers,
-    Dio? dioClient,
     this.silenceExceptions = false,
-  }) : _dioClient = dioClient ?? Dio();
+  });
 
   /// Whether to ignore exceptions and errors that occur whilst fetching tiles
   /// over the network, and just return a transparent tile
@@ -64,7 +63,8 @@ base class CancellableNetworkTileProvider extends TileProvider {
 
   /// Long living client used to make all tile requests by [CancellableNetworkImageProvider]
   /// for the duration that this provider is alive
-  final Dio _dioClient;
+  /// Use dio singleton
+  final Dio _dioClient = DioSingleton.dioInstance;
 
   /// Each [Completer] is completed once the corresponding tile has finished
   /// loading
@@ -88,7 +88,6 @@ base class CancellableNetworkTileProvider extends TileProvider {
         url: getTileUrl(coordinates, options),
         fallbackUrl: getTileFallbackUrl(coordinates, options),
         headers: headers,
-        dioClient: _dioClient,
         cancelLoading: cancelLoading,
         silenceExceptions: silenceExceptions,
         startedLoading: () => _tilesInProgress[coordinates] = Completer(),
@@ -103,7 +102,6 @@ base class CancellableNetworkTileProvider extends TileProvider {
     if (_tilesInProgress.isNotEmpty) {
       await Future.wait(_tilesInProgress.values.map((c) => c.future));
     }
-    _dioClient.close();
     super.dispose();
   }
 }


### PR DESCRIPTION
### **Background**

A while back, I noticed that my tile server periodically would accumulate "CLOSE_WAIT" states, resulting in a gradual slowing and eventual need for a reboot. Upon researching this topic, the overarching theme was that the client was not closing connections properly, leaving the server in a confused state:

> "CLOSE_WAIT - Indicates that the server has received the first FIN signal from the client and the connection is in the process of being closed. This means the socket is waiting for the application to execute close() . A socket can be in CLOSE_WAIT state indefinitely until the application closes it."

The issue was rare enough I made a monitoring script on my server that would auto-reboot if CLOSE_WAIT count got too high. 
I then turned to development on iOS as Android was mostly done.

### **iOS Restart Issue**

My iOS app would run great on first install.  But then if I killed it and restarted, when it came up, it would have many missing tiles and just slow in general. Common debugger errors (hundreds) included: 

```
Error: SocketException: Connection failed (OS Error: Too many open files, errno = 24), 
SocketException: Failed host lookup: 'site.com' (OS Error: nodename nor servname provided, or not known, errno = 8),
```
Sometimes I even got missing asset errors.  This suggested file descriptor exhaustion.

Strangely, these errors only occurred on a physical iPhone.  iOS simulators worked great, so did all my Android devices (aside from periodic CLOSE_WAIT issues seen on my server). The fix was to restart the app about 4 times, which must have cleared out "something" from memory.  App would then work great, until next time. Rinse & repeat.

### **Initial Debugging**

I decided to play around with local pub dev copy of tile_provider.dart and image_provider.dart, focusing on the closing of the connections.  tile_provider.dart already had this:

```
  @override
  Future<void> dispose() async {
    if (_tilesInProgress.isNotEmpty) {
      await Future.wait(_tilesInProgress.values.map((c) => c.future));
    }
    _dioClient.close();
    super.dispose();
  }

```  
but perhaps not all connections were being closed properly. I added a print statement, and noticed upon normal map usage, hundreds of prints, suggesting frequent creation and attempted closing of dio clients.

I had previously stumbled upon a Dart thread with similar errors, and they suggested using cupertino_http, and/or native_dio_adapter which includes that along with cronet for Android. Clearly dio was not playing nice with iPhones, so I gave it a shot. 

I also hypothesized that maybe only a single dio client was actually needed, instead of creating and destroying constantly. That way, previously used resources could be reused.

### **Result**
Success!  Not only was I able to restart my iPhone app as frequently as I wanted with zero errors, but the tiles are FLYING IN.  
At least for my app, it's night and day.  Sometimes I can't even tell it's tiled, more like a seamless map. And when I zoom out quickly, instead of checker-board loading, they all load nearly simultaneously.

### **Who May Benefit (Most) & Testing**

While more testing is needed, clearly anyone with the same errors I was experiencing on iPhones should test these changes.
After two days of usage, I have seen no ill effects.  On the contrary. 

It should be noted that in my application, I use MANY TIleLayer() at once (12+).  Probably a somewhat rare amount, but it should work all the same.

Very few lines of code were needed as you can see.  I import native_dio_adapter, created a singleton of dio, and removed the _dioClient.close().  In addition, I create a CancellableNetworkTileProvider instance once in initState and use _tileProvider in all of my tile layers:

```
_tileProvider = CancellableNetworkTileProvider();

TileLayer(
  tileProvider: _tileProvider,
  ...
),
```

It seems clear to me that at least for iOS, sometimes dio instances were not all getting closed properly. But this must have also been true for Android, just to a lesser extent, given my experience with CLOSE_WAIT on my tile server.  Installing the native adapters fixed the file descriptors running out error on iPhone, and I'm guessing I will no longer get the server errors.

Errors aside, I am guessing that the more TileLayer() you have in your app, the more of a speed increase you will see.

I am eager to hear if this works for you!  

PS: if this works well for everyone, you might also consider the same for NetworkTileProvider, which I do not currently use.








