### PR TITLE
fix: avoid closing externally created `Dio` client in `CancellableNetworkTileProvider`

### DIFF
--- a/lib/src/tile_provider.dart
+++ b/lib/src/tile_provider.dart
@@ -56,7 +56,8 @@ base class CancellableNetworkTileProvider extends TileProvider {
     super.headers,
     Dio? dioClient,
     this.silenceExceptions = false,
-  }) : _dioClient = dioClient ?? Dio();
+  })  : _isInternallyCreatedClient = dioClient == null,
+        _dioClient = dioClient ?? Dio();
 
   /// Whether to ignore exceptions and errors that occur whilst fetching tiles
   /// over the network, and just return a transparent tile
@@ -64,7 +65,13 @@ base class CancellableNetworkTileProvider extends TileProvider {
 
   /// Long living client used to make all tile requests by [CancellableNetworkImageProvider]
   /// for the duration that this provider is alive
+  ///
+  /// Not automatically closed if created externally and passed as an argument
+  /// during construction.
   final Dio _dioClient;
+
+  /// Whether [_dioClient] was created on construction (and not passed in)
+  final bool _isInternallyCreatedClient;
 
   /// Each [Completer] is completed once the corresponding tile has finished
   /// loading
@@ -103,7 +110,7 @@ base class CancellableNetworkTileProvider extends TileProvider {
     if (_tilesInProgress.isNotEmpty) {
       await Future.wait(_tilesInProgress.values.map((c) => c.future));
     }
-    _dioClient.close();
+    if (_isInternallyCreatedClient) _dioClient.close();
     super.dispose();
   }
 }


### PR DESCRIPTION
Follows up on https://github.com/fleaflet/flutter_map/issues/2009.